### PR TITLE
Add Excel helper utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,23 @@ npm install @form-create/element-ui@next
 ![https://raw.githubusercontent.com/xaboy/form-create/dev/images/sample110.jpg](https://raw.githubusercontent.com/xaboy/form-create/dev/images/sample110.jpg)
 </details>
 
+## Excel Import/Export
+
+Starting from this version, form-create provides basic helpers for reading
+and writing Excel files. Utilities `readExcel` and `writeExcel` are exported
+from `@form-create/utils` and rely on the [xlsx](https://github.com/SheetJS/sheetjs)
+library.
+
+```js
+import { readExcel, writeExcel } from '@form-create/utils'
+
+// read ArrayBuffer or File
+const rows = readExcel(file)
+
+// export data
+writeExcel(rows, 'table.xlsx')
+```
+
 
 ## 联系
 ![http://static.form-create.com/file/img/support.jpg](http://static.form-create.com/file/img/support.jpg)

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
         "commander": "^6.0.0",
         "dayjs": "^1.10.7",
         "postcss": "^8.3.6",
-        "vue": "^3.5.8",
-        "wangeditor": "^4.7.8"
+    "vue": "^3.5.8",
+        "wangeditor": "^4.7.8",
+        "xlsx": "^0.18.5"
     }
 }

--- a/packages/utils/lib/excel.js
+++ b/packages/utils/lib/excel.js
@@ -1,0 +1,33 @@
+import XLSX from 'xlsx';
+
+/**
+ * Read Excel data from an ArrayBuffer or File object
+ * @param {ArrayBuffer|File} input
+ * @returns {Array<Object>} parsed data
+ */
+export function readExcel(input) {
+  let buffer;
+  if (input instanceof ArrayBuffer) {
+    buffer = input;
+  } else if (input && typeof input.arrayBuffer === 'function') {
+    buffer = input.arrayBuffer();
+  } else {
+    throw new Error('Unsupported input type for readExcel');
+  }
+  const arr = new Uint8Array(buffer);
+  const workbook = XLSX.read(arr, { type: 'array' });
+  const sheet = workbook.SheetNames[0];
+  return XLSX.utils.sheet_to_json(workbook.Sheets[sheet], { defval: '' });
+}
+
+/**
+ * Export JSON data to an Excel file
+ * @param {Array<Object>} data
+ * @param {String} filename
+ */
+export function writeExcel(data, filename = 'export.xlsx') {
+  const ws = XLSX.utils.json_to_sheet(data);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+  XLSX.writeFile(wb, filename);
+}

--- a/packages/utils/lib/index.js
+++ b/packages/utils/lib/index.js
@@ -11,3 +11,4 @@ export {default as is} from './type';
 export {default as uniqueId} from './unique';
 export {default as getSlot} from './slot';
 export {default as deepSet} from './deepset';
+export {readExcel, writeExcel} from './excel';


### PR DESCRIPTION
## Summary
- provide simple Excel read/write helpers in utils
- export these helper functions
- document Excel import/export utilities
- add `xlsx` as a dependency

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*